### PR TITLE
Fixed project name and country code in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Or simply add the script at the bottom of your html page:
 ```
 
 ## Basic Usage
-If you are using npm to require Localise.js, pass options within the `require`. See Attribute Options below for possible arguments
+If you are using npm to require Localize.js, pass options within the `require`. See Attribute Options below for possible arguments
 ```
 var localize = require('localize-js')(options)
 ```
@@ -37,7 +37,7 @@ Now in your root directory, create a new directory called `translations`, and ad
 |   ├── en.json
 |   ├── fr.json
 |   ├── ru.json
-|   └── en-UK.json
+|   └── en-GB.json
 </pre>
 
 JSON files should have a basic key-value structure like:


### PR DESCRIPTION
* Localize.js instead of Localise.js
* en-GB instead of en-UK: `GB` is the ISO 639-1 Alpha-2 country code for the
  United Kingdom while `UK` is an undefined (but reserved) code; `en-GB` is
  the standard locale code for British English